### PR TITLE
v0.2.7 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ overhead.
 <dependency>
 <groupId>com.logicalbias</groupId>
 <artifactId>dropwizard-testing</artifactId>
-<version>0.2.6</version>
+<version>0.2.7</version>
 <scope>test</scope>
 </dependency>
 ```
@@ -39,7 +39,7 @@ overhead.
 
 ```groovy
 dependencies {
-    testImplementation 'com.logicalbias:dropwizard-testing:0.2.6'
+    testImplementation 'com.logicalbias:dropwizard-testing:0.2.7'
 }
 ```
 

--- a/dropwizard-testing-dynamo/README.md
+++ b/dropwizard-testing-dynamo/README.md
@@ -10,7 +10,7 @@
 <dependency>
   <groupId>com.logicalbias</groupId>
   <artifactId>dropwizard-testing-dynamo</artifactId>
-  <version>0.2.3</version>
+  <version>0.2.7</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -19,7 +19,7 @@
 
 ```groovy
 dependencies {
-    testImplementation 'com.logicalbias:dropwizard-testing-dynamo:0.2.3'
+    testImplementation 'com.logicalbias:dropwizard-testing-dynamo:0.2.7'
 }
 ```
 
@@ -27,7 +27,7 @@ dependencies {
 
 Using this library is easy. Simply add `@DynamoDbTest` annotation to your class. This will (by default) spin up an in-memory dynamo database.
 Alternatively, the annotation environment property is provided `@DynamoDbTest(environment = Environment.DOCKER)` allowing control to spin up a full
-docker container (this requires the [Test Containers](https://testcontainers.com/) dependency to be added to yyour project.
+docker container (this requires the [Test Containers](https://testcontainers.com/) dependency to be added to your project.
 
 ```java
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;

--- a/dropwizard-testing-dynamo/pom.xml
+++ b/dropwizard-testing-dynamo/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.logicalbias</groupId>
         <artifactId>dropwizard-testing-parent</artifactId>
-        <version>0.2.7-SNAPSHOT</version>
+        <version>0.2.7</version>
         <relativePath>../dropwizard-testing-parent</relativePath>
     </parent>
 

--- a/dropwizard-testing-dynamo/src/main/java/com/logicalbias/dropwizard/testing/dynamo/DynamoService.java
+++ b/dropwizard-testing-dynamo/src/main/java/com/logicalbias/dropwizard/testing/dynamo/DynamoService.java
@@ -43,7 +43,7 @@ interface DynamoService {
 
         DynamoEmbedded() {
             log.info("Starting embedded dynamoDb for testing.");
-            this.embeddedDb = DynamoDBEmbedded.create(true);
+            this.embeddedDb = DynamoDBEmbedded.create();
         }
 
         @Override

--- a/dropwizard-testing-kafka/README.md
+++ b/dropwizard-testing-kafka/README.md
@@ -1,0 +1,3 @@
+# Dropwizard Kafka Testing
+
+Not ready for use.

--- a/dropwizard-testing-kafka/pom.xml
+++ b/dropwizard-testing-kafka/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.logicalbias</groupId>
         <artifactId>dropwizard-testing-parent</artifactId>
-        <version>0.2.7-SNAPSHOT</version>
+        <version>0.2.7</version>
         <relativePath>../dropwizard-testing-parent</relativePath>
     </parent>
 

--- a/dropwizard-testing-parent/pom.xml
+++ b/dropwizard-testing-parent/pom.xml
@@ -27,7 +27,7 @@
         <dropwizard-testing.version>0.2.7-SNAPSHOT</dropwizard-testing.version>
         <dropwizard.version>4.0.1</dropwizard.version>
         <spring-kafka.version>3.2.0</spring-kafka.version>
-        <dynamodb-local.version>2.5.3</dynamodb-local.version>
+        <dynamodb-local.version>2.2.0</dynamodb-local.version>
         <testcontainers.version>1.20.4</testcontainers.version>
         <lombok.version>1.18.32</lombok.version>
 
@@ -123,6 +123,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
+                <configuration>
+                    <additionalOptions>-Xdoclint:none</additionalOptions>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/dropwizard-testing-parent/pom.xml
+++ b/dropwizard-testing-parent/pom.xml
@@ -25,16 +25,16 @@
 
         <!-- dependency versions -->
         <dropwizard-testing.version>0.2.7-SNAPSHOT</dropwizard-testing.version>
-        <dropwizard.version>4.0.1</dropwizard.version>
+        <dropwizard.version>4.0.12</dropwizard.version>
         <spring-kafka.version>3.2.0</spring-kafka.version>
         <dynamodb-local.version>2.2.0</dynamodb-local.version>
-        <testcontainers.version>1.20.4</testcontainers.version>
-        <lombok.version>1.18.32</lombok.version>
+        <testcontainers.version>1.20.6</testcontainers.version>
+        <lombok.version>1.18.36</lombok.version>
 
         <!-- plugin versions -->
-        <maven-javadoc-plugin.version>3.11.1</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-flatten-plugin.version>1.6.0</maven-flatten-plugin.version>
+        <maven-flatten-plugin.version>1.7.0</maven-flatten-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
     </properties>

--- a/dropwizard-testing-parent/pom.xml
+++ b/dropwizard-testing-parent/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.logicalbias</groupId>
         <artifactId>dropwizard-testing-project</artifactId>
-        <version>0.2.7-SNAPSHOT</version>
+        <version>0.2.7</version>
     </parent>
 
     <name>Dropwizard Integration Testing Parent</name>
@@ -24,7 +24,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- dependency versions -->
-        <dropwizard-testing.version>0.2.7-SNAPSHOT</dropwizard-testing.version>
+        <dropwizard-testing.version>0.2.7</dropwizard-testing.version>
         <dropwizard.version>4.0.12</dropwizard.version>
         <spring-kafka.version>3.2.0</spring-kafka.version>
         <dynamodb-local.version>2.2.0</dynamodb-local.version>

--- a/dropwizard-testing-parent/pom.xml
+++ b/dropwizard-testing-parent/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.logicalbias</groupId>
         <artifactId>dropwizard-testing-parent</artifactId>
-        <version>0.2.7-SNAPSHOT</version>
+        <version>0.2.7</version>
         <relativePath>../dropwizard-testing-parent</relativePath>
     </parent>
 

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/annotation/Import.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/annotation/Import.java
@@ -12,7 +12,11 @@ import org.glassfish.jersey.Beta;
 
 /**
  * <p>
- * Defines a class which will be automatically added to the dropwizard hk2 context.
+ * Defines a class which will be automatically added to the dropwizard HK2 context.
+ * The class should utilize {@link org.jvnet.hk2.annotations.Service} and
+ * {@link org.jvnet.hk2.annotations.ContractsProvided} annotations to define
+ * the bean names and additional contracts. All imported beans will be automatically
+ * bound to themselves.
  * </p>
  */
 @Beta
@@ -22,5 +26,15 @@ import org.glassfish.jersey.Beta;
 @Documented
 @Inherited
 public @interface Import {
+
+    /**
+     * The class or set of classes to inject into the HK2 context.
+     */
     Class<?>[] value();
+
+    /**
+     * The name of the mock. This is ignored if {@link Import#value} contains more than one value.
+     * If set, this will override any @Service annotations placed on the imported class.
+     */
+    String name() default "";
 }

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/annotation/MockBean.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/annotation/MockBean.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 /**
  * <p>
  * Defines what classes will be mocked within the {@link com.logicalbias.dropwizard.testing.extension.context.DropwizardTest}
- * application context. The mocks will be automatically generated and injected into the hk2 context for duration of the
+ * application context. The mocks will be automatically generated and injected into the HK2 context for duration of the
  * test class.
  * </p>
  * <p>

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/annotation/MockBean.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/annotation/MockBean.java
@@ -29,12 +29,13 @@ import java.lang.annotation.Target;
 public @interface MockBean {
 
     /**
-     * The type of mock to inject. This is required when used on the class level. Ignored when used on a class property.
+     * The type of mock to inject. This is required when used at the class level and
+     * ignored when used at the field level; field type is used directly.
      */
     Class<?>[] value() default {};
 
     /**
-     * The name of the mock. This is ignored if more than one type is mocked in a single {@link MockBean} declaration.
+     * The name of the mock. This is ignored if {@link MockBean#value} contains more than one value.
      */
     String name() default "";
 }

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/DropwizardTestExtension.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/DropwizardTestExtension.java
@@ -1,5 +1,6 @@
 package com.logicalbias.dropwizard.testing.extension.context;
 
+import jakarta.inject.Named;
 import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -24,7 +25,7 @@ class DropwizardTestExtension implements
     static final Namespace NAMESPACE = Namespace.create(DropwizardTestExtension.class);
 
     @Override
-    public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
+    public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
         testContextManager(context).afterConstructor(testInstance);
     }
 
@@ -53,7 +54,9 @@ class DropwizardTestExtension implements
         }
 
         var parameterizedType = parameterContext.getParameter().getParameterizedType();
-        return testContext.getBean(rawType, parameterizedType) != null;
+        var beanName = parameterContext.findAnnotation(Named.class).map(Named::value).orElse(null);
+
+        return testContext.getBean(rawType, parameterizedType, beanName) != null;
     }
 
     @Override
@@ -66,7 +69,9 @@ class DropwizardTestExtension implements
         }
 
         var parameterizedType = parameterContext.getParameter().getParameterizedType();
-        return testContext.getBean(rawType, parameterizedType);
+        var beanName = parameterContext.findAnnotation(Named.class).map(Named::value).orElse(null);
+
+        return testContext.getBean(rawType, parameterizedType, beanName);
     }
 
     private static TestClient getTestClient(ExtensionContext context) {

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/ExtensionHooks.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/ExtensionHooks.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * It provides hook points allowing dropwizard test extensions to:
  * </p>
  * <ul>
- * <li>extensions to add or override dependencies in the HK2 context</li>
- * <li>extensions to add or override properties in the running application</li>
+ * <li>add or override dependencies in the HK2 context</li>
+ * <li>add or override properties in the running application</li>
  * </ul>
  *
  * <pre>

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/ExtensionHooks.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/ExtensionHooks.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * It provides hook points allowing dropwizard test extensions to:
  * </p>
  * <ul>
- * <li>extensions to add or override dependencies in the hk2 context</li>
+ * <li>extensions to add or override dependencies in the HK2 context</li>
  * <li>extensions to add or override properties in the running application</li>
  * </ul>
  *

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/ImportContext.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/ImportContext.java
@@ -1,22 +1,75 @@
 package com.logicalbias.dropwizard.testing.extension.context;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
+import org.jvnet.hk2.annotations.ContractsProvided;
+import org.jvnet.hk2.annotations.Service;
 
 import com.logicalbias.dropwizard.testing.extension.annotation.Import;
 
 class ImportContext {
 
-    static List<Class<?>> getImportClassTypes(ExtensionContext context) {
-        var testClass = context.getRequiredTestClass();
-        var imports = AnnotationSupport.findRepeatableAnnotations(testClass, Import.class);
-        return imports.stream()
-                .flatMap(imp -> Arrays.stream(imp.value()))
-                .collect(Collectors.toList());
+    private final List<ImportDefinition> imports = new ArrayList<>();
 
+    ImportContext(ExtensionContext context) {
+        var testClass = context.getRequiredTestClass();
+
+        loadImportsFromAnnotations(testClass);
+    }
+
+    void forEach(Consumer<ImportDefinition> action) {
+        imports.forEach(action);
+    }
+
+    private void loadImportsFromAnnotations(Class<?> testClass) {
+        // Scan for @Import annotations and store their information
+        var importBeans = AnnotationSupport.findRepeatableAnnotations(testClass, Import.class);
+        for (var importBean : importBeans) {
+            for (var importType : importBean.value()) {
+                // Only use bean name definition if exactly one mock type is specified on the @MockBean annotation.
+                var name = importBean.value().length <= 1 ? importBean.name() : null;
+                imports.add(new ImportDefinition(importType, name));
+            }
+        }
+    }
+
+    @Getter
+    @Accessors(fluent = true)
+    @EqualsAndHashCode
+    @RequiredArgsConstructor
+    static class ImportDefinition {
+        private final Class<?> type;
+        private final String name;
+        private final Class<?>[] contractsProvided;
+
+        ImportDefinition(Class<?> type, String name) {
+            this.type = type;
+            this.name = getServiceName(type, name);
+            this.contractsProvided = getContractsProvided(type);
+        }
+
+        private String getServiceName(Class<?> type, String name) {
+            return StringUtils.getIfBlank(name, () -> AnnotationSupport.findAnnotation(type, Service.class)
+                    .map(Service::name)
+                    .orElse(null)
+            );
+        }
+
+        private Class<?>[] getContractsProvided(Class<?> type) {
+            return AnnotationSupport.findAnnotation(type, ContractsProvided.class)
+                    .map(ContractsProvided::value)
+                    .orElseGet(() -> new Class[0]);
+
+        }
     }
 }

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/TestContextManager.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/TestContextManager.java
@@ -38,6 +38,7 @@ class TestContextManager {
     private final ExtensionContext context;
     private final DependencyContext dependencyContext;
     private final MockContext mockContext;
+    private final ImportContext importContext;
     private final List<ConfigOverride> configOverrides;
 
     private DropwizardAppExtension<?> appExtension;
@@ -56,6 +57,7 @@ class TestContextManager {
         this.context = context;
         this.dependencyContext = new DependencyContext();
         this.mockContext = new MockContext(context);
+        this.importContext = new ImportContext(context);
         this.configOverrides = new ArrayList<>();
     }
 

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/TestServiceListener.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/TestServiceListener.java
@@ -11,9 +11,6 @@ import java.lang.reflect.Type;
 
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.hk2.utilities.binding.ServiceBindingBuilder;
-import org.junit.platform.commons.support.AnnotationSupport;
-import org.jvnet.hk2.annotations.ContractsProvided;
-import org.jvnet.hk2.annotations.Service;
 
 /**
  * ServiceListener will run before the target application 'run' method is invoked on service startup. This listener
@@ -28,9 +25,9 @@ class TestServiceListener<C extends Configuration> extends DropwizardAppExtensio
     @Override
     public void onRun(C configuration, Environment environment, DropwizardAppExtension<C> rule) {
         // First look for imported classes and register them directly as a jersey component
-        var context = testContextManager.getContext();
-        var importedClasses = ImportContext.getImportClassTypes(context);
-        importedClasses.forEach(environment.jersey()::register);
+        testContextManager.getImportContext().forEach(importDef -> {
+            environment.jersey().register(importDef.type());
+        });
 
         environment.jersey().register(new TestBinder(testContextManager));
     }
@@ -47,35 +44,27 @@ class TestServiceListener<C extends Configuration> extends DropwizardAppExtensio
             testContextManager.getMockContext().forEach(this::bind);
             testContextManager.getDependencyContext().forEach(this::bind);
 
-            bindImportedTypes();
-        }
-
-        private void bindImportedTypes() {
-            // Bind our imported classes into the DI context as well
-            var importedClasses = ImportContext.getImportClassTypes(testContextManager.getContext());
-            importedClasses.forEach(type -> {
-                var name = AnnotationSupport.findAnnotation(type, Service.class)
-                        .map(Service::name)
-                        .orElse(null);
-
-                var contractTypes = AnnotationSupport.findAnnotation(type, ContractsProvided.class)
-                        .map(ContractsProvided::value)
-                        .orElseGet(() -> new Class[0]);
-
-                // Bind type to itself as well as all additional provided contracts
-                var binding = bindAsContract(type);
-                for (var contractType : contractTypes) {
-                    binding = binding.to(contractType);
-                }
-                binding.named(name)
-                        .in(Singleton.class)
-                        .ranked(Integer.MAX_VALUE);
-            });
+            testContextManager.getImportContext().forEach(this::bind);
         }
 
         @SuppressWarnings("unchecked")
         private <T> void bind(MockContext.MockDefinition mockDefinition, T mock) {
             bind(mockDefinition.type(), mockDefinition.name(), mock);
+        }
+
+        private <T> void bind(ImportContext.ImportDefinition importDefinition) {
+            var type = importDefinition.type();
+            var name = importDefinition.name();
+            var contractTypes = importDefinition.contractsProvided();
+
+            // Bind type to itself as well as all additional provided contracts
+            var binding = bindAsContract(type);
+            for (var contractType : contractTypes) {
+                binding = binding.to(contractType);
+            }
+            binding.named(name)
+                    .in(Singleton.class)
+                    .ranked(Integer.MAX_VALUE);
         }
 
         private <T> void bind(DependencyContext.DependencyInfo<T> dependencyInfo) {

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/TestServiceListener.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/context/TestServiceListener.java
@@ -10,11 +10,10 @@ import lombok.RequiredArgsConstructor;
 import java.lang.reflect.Type;
 
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.hk2.utilities.binding.ServiceBindingBuilder;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.jvnet.hk2.annotations.ContractsProvided;
 import org.jvnet.hk2.annotations.Service;
-
-import static com.logicalbias.dropwizard.testing.extension.utils.TestHelpers.buildTypeLiteral;
 
 /**
  * ServiceListener will run before the target application 'run' method is invoked on service startup. This listener
@@ -76,26 +75,19 @@ class TestServiceListener<C extends Configuration> extends DropwizardAppExtensio
 
         @SuppressWarnings("unchecked")
         private <T> void bind(MockContext.MockDefinition mockDefinition, T mock) {
-            bind((Class<T>) mockDefinition.type(), mockDefinition.typeArguments(), mockDefinition.name(), mock);
+            bind(mockDefinition.type(), mockDefinition.name(), mock);
         }
 
         private <T> void bind(DependencyContext.DependencyInfo<T> dependencyInfo) {
-            bind(dependencyInfo.classType(), null, dependencyInfo.name(), dependencyInfo.instance());
+            bind(dependencyInfo.classType(), dependencyInfo.name(), dependencyInfo.instance());
         }
 
-        private <T> void bind(Class<T> type, Type[] typeArguments, String name, T instance) {
-            if (typeArguments == null || typeArguments.length == 0) {
-                bind(instance)
-                        .to(type)
-                        .named(name == null || name.isBlank() ? null : name)
-                        .ranked(Integer.MAX_VALUE);
-            }
-            else {
-                bind(instance)
-                        .to(buildTypeLiteral(type, typeArguments))
-                        .named(name == null || name.isBlank() ? null : name)
-                        .ranked(Integer.MAX_VALUE);
-            }
+        @SuppressWarnings("unchecked")
+        private <T> void bind(Type type, String name, T instance) {
+            var binding = (ServiceBindingBuilder<T>) bind(instance);
+            binding.to(type)
+                    .named(name == null || name.isBlank() ? null : name)
+                    .ranked(Integer.MAX_VALUE);
         }
     }
 }

--- a/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/utils/TestHelpers.java
+++ b/dropwizard-testing/src/main/java/com/logicalbias/dropwizard/testing/extension/utils/TestHelpers.java
@@ -1,15 +1,11 @@
 package com.logicalbias.dropwizard.testing.extension.utils;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
 import java.util.ArrayDeque;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import org.glassfish.hk2.api.TypeLiteral;
-import org.glassfish.hk2.utilities.reflection.ParameterizedTypeImpl;
 
 public final class TestHelpers {
 
@@ -87,28 +83,5 @@ public final class TestHelpers {
         }
 
         return List.copyOf(inheritedTypes);
-    }
-
-    public static <T> TypeLiteral<T> buildTypeLiteral(Class<T> rawType, Type[] typeArguments) {
-        try {
-            var parameterizedType = new ParameterizedTypeImpl(rawType, typeArguments);
-            var typeLiteral = new TypeLiteral<T>() {
-            };
-
-            // Terrible reflective hacks to create the appropriate TypeLiteral
-            // But glassfish doesn't really provide any better options here
-            var typeField = TypeLiteral.class.getDeclaredField("type");
-            typeField.setAccessible(true);
-            typeField.set(typeLiteral, parameterizedType);
-
-            var rawTypeField = TypeLiteral.class.getDeclaredField("rawType");
-            rawTypeField.setAccessible(true);
-            rawTypeField.set(typeLiteral, rawType);
-
-            return typeLiteral;
-        }
-        catch (IllegalAccessException | NoSuchFieldException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/dropwizard-testing/src/test/java/com/logicalbias/dropwizard/testing/NamedBeanExtensionTest.java
+++ b/dropwizard-testing/src/test/java/com/logicalbias/dropwizard/testing/NamedBeanExtensionTest.java
@@ -1,0 +1,68 @@
+package com.logicalbias.dropwizard.testing;
+
+import jakarta.inject.Named;
+import lombok.RequiredArgsConstructor;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.hk2.annotations.ContractsProvided;
+import org.jvnet.hk2.annotations.Service;
+
+import com.logicalbias.dropwizard.testing.application.DropwizardTestApplication;
+import com.logicalbias.dropwizard.testing.extension.annotation.Import;
+import com.logicalbias.dropwizard.testing.extension.context.DropwizardTest;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+@DropwizardTest(value = DropwizardTestApplication.class, configFile = "config.yml", properties = "name=TestApp")
+@Import(NamedBeanExtensionTest.TestBean2.class)
+@Import(value = NamedBeanExtensionTest.TestBean1.class, name = "testBean1")
+@Import(value = NamedBeanExtensionTest.TestBean3.class, name = "testBean3")
+@RequiredArgsConstructor
+public class NamedBeanExtensionTest {
+
+    private final TestInterface defaultTestInterface;
+
+    @Named("testBean1")
+    private final TestInterface testInterface1;
+
+    @Named("testBean2")
+    private final TestInterface testInterface2;
+
+    @Named("testBean3")
+    private final TestInterface testInterface3;
+
+    private final TestBean1 testBean1;
+    private final TestBean2 testBean2;
+    private final TestBean3 testBean3;
+
+    @Test
+    void testNamedBeansInjected() {
+
+        // TestBean2 defined first; it should be the default
+        assertInstanceOf(TestBean2.class, defaultTestInterface);
+
+        assertInstanceOf(TestBean1.class, testInterface1);
+        assertInstanceOf(TestBean2.class, testInterface2);
+        assertInstanceOf(TestBean3.class, testInterface3);
+        assertInstanceOf(TestBean1.class, testBean1);
+        assertInstanceOf(TestBean2.class, testBean2);
+        assertInstanceOf(TestBean3.class, testBean3);
+    }
+
+    public interface TestInterface {
+    }
+
+    @Service(name = "should-be-ignored")
+    @ContractsProvided(TestInterface.class)
+    public static class TestBean1 implements TestInterface {
+    }
+
+    @Service(name = "testBean2")
+    @ContractsProvided(TestInterface.class)
+    public static class TestBean2 implements TestInterface {
+    }
+
+    @ContractsProvided(TestInterface.class)
+    public static class TestBean3 implements TestInterface {
+    }
+}

--- a/dropwizard-testing/src/test/java/com/logicalbias/dropwizard/testing/TestClientTest.java
+++ b/dropwizard-testing/src/test/java/com/logicalbias/dropwizard/testing/TestClientTest.java
@@ -1,10 +1,12 @@
 package com.logicalbias.dropwizard.testing;
 
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -23,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Slf4j
 @DropwizardTest(value = DropwizardTestApplication.class, configFile = "config.yml")
 @RequiredArgsConstructor
-public class ApplicationTestClientTest {
+public class TestClientTest {
 
     private final DropwizardAppExtension<ApplicationConfiguration> appExtension;
     private final ApplicationConfiguration configuration;
@@ -37,11 +39,56 @@ public class ApplicationTestClientTest {
     }
 
     @Test
-    void testQueryParams() {
+    void testAddQueryParams() {
         var response = client.get("widgets/params")
                 .queryParam("stringValue", "Test String")
                 .queryParam("listValue", "Value1", "Value2")
                 .queryParam("intValue", 27)
+                .andReturn(JsonNode.class);
+        log.info("{}", response);
+
+        assertEquals("Test String", response.path("stringValue").asText());
+        assertTrue(response.path("listValue").isArray());
+        var listValue = StreamSupport.stream(response.path("listValue").spliterator(), false)
+                .map(JsonNode::asText)
+                .collect(Collectors.toList());
+
+        assertEquals(List.of("Value1", "Value2"), listValue);
+        assertEquals(27, response.path("intValue").asInt());
+    }
+
+    @Test
+    void testQueryMap() {
+        // Can't use a standard map to send in a list of values; must use the multimap api for that
+        var response = client.get("widgets/params")
+                .queryParams(Map.of(
+                        "stringValue", "Test String",
+                        "listValue", "Value1",
+                        "intValue", 27
+                ))
+                .andReturn(JsonNode.class);
+        log.info("{}", response);
+
+        assertEquals("Test String", response.path("stringValue").asText());
+        assertTrue(response.path("listValue").isArray());
+        var listValue = StreamSupport.stream(response.path("listValue").spliterator(), false)
+                .map(JsonNode::asText)
+                .collect(Collectors.toList());
+
+        assertEquals(List.of("Value1"), listValue);
+        assertEquals(27, response.path("intValue").asInt());
+    }
+
+    @Test
+    void testQueryParamMultiMap() {
+        var multiMap = new MultivaluedHashMap<String, Object>(Map.of(
+                "stringValue", "Test String",
+                "intValue", 27
+        ));
+        multiMap.put("listValue", List.of("Value1", "Value2"));
+
+        var response = client.get("widgets/params")
+                .queryParams(multiMap)
                 .andReturn(JsonNode.class);
         log.info("{}", response);
 

--- a/dropwizard-testing/src/test/java/com/logicalbias/dropwizard/testing/application/DropwizardTestApplication.java
+++ b/dropwizard-testing/src/test/java/com/logicalbias/dropwizard/testing/application/DropwizardTestApplication.java
@@ -63,22 +63,24 @@ public class DropwizardTestApplication extends Application<ApplicationConfigurat
         }
 
         void bindGenericServices() {
-            bindAsContract(StringService.class)
-                    .in(Singleton.class)
+            bind(StringService.class)
+                    .to(StringService.class)
                     .to(new TypeLiteral<GenericService<String>>() {
-                    });
+                    })
+                    .in(Singleton.class);
 
-            bindAsContract(NumberService.class)
-                    .in(Singleton.class)
+            bind(NumberService.class)
+                    .to(NumberService.class)
                     .to(new TypeLiteral<GenericService<Number>>() {
-                    });
+                    })
+                    .in(Singleton.class);
         }
     }
 
     static class ApplicationHealthCheck extends HealthCheck {
 
         @Override
-        protected Result check() throws Exception {
+        protected Result check() {
             return Result.healthy();
         }
     }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,3 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true
+lombok.copyableAnnotations += jakarta.inject.Named

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.logicalbias</groupId>
     <artifactId>dropwizard-testing-project</artifactId>
-    <version>0.2.7-SNAPSHOT</version>
+    <version>0.2.7</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
- Remove reflective buildTypeLiteral hack in lieu of (slightly) better hopeful cast to ServiceBindingBuilder allowing injection of parameterized type directly.